### PR TITLE
upgraded to 1.0.1-SNAPSHOT to prevent clashing with Dashbuilder version

### DIFF
--- a/kie-docker-ui-docker-image/pom.xml
+++ b/kie-docker-ui-docker-image/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.docker</groupId>
     <artifactId>kie-docker-ci</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-docker-ui-docker-image</artifactId>
@@ -36,7 +36,6 @@
       <artifactId>kie-docker-ui-webapp</artifactId>
       <type>war</type>
       <classifier>wildfly10</classifier>
-      <version>1.0.0-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/kie-docker-ui-webapp/pom.xml
+++ b/kie-docker-ui-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.docker</groupId>
     <artifactId>kie-docker-ci</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-docker-ui-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.kie.docker</groupId>
   <artifactId>kie-docker-ci</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>KIE :: Docker Continuous Integration</name>
 


### PR DESCRIPTION
hope this makes sense - this is to prevent the removing of the kie-docker-ci-webapp container due to docker-clean.sh:  
https://github.com/kiegroup/kie-docker-ci-images/issues/14