### PR TITLE
upgrade of fasterxml.jackson because of security vulnerability report…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <version.org.mortbay.jetty>6.1.25</version.org.mortbay.jetty>
     <version.mysql>5.1.35</version.mysql>
     <version.postgresql>9.1-901-1.jdbc4</version.postgresql>
-    <version.com.fasterxml.jackson.core>2.4.0</version.com.fasterxml.jackson.core>
+    <version.com.fasterxml.jackson.core>2.6.7.1</version.com.fasterxml.jackson.core>
     <version.com.fasterxml.jackson.module>2.1.2</version.com.fasterxml.jackson.module>
   </properties>
 


### PR DESCRIPTION
…ed by github

Known  high severity security vulnerability detected in com.fasterxml.jackson.core:jackson-databind < 2.6.7.1 defined in pom.xml.
--
pom.xml update suggested: com.fasterxml.jackson.core:jackson-databind ~> 2.6.7.1.

